### PR TITLE
add-default-aws-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configure `IAMAuthenticatorConfig` to allow role `GiantSwarmAdmin` to get `cluster-admin` privileges in the EKS cluster.
+
 ## [0.3.2] - 2023-08-04
 
 ### Added

--- a/helm/cluster-eks/ci/ci-values.yaml
+++ b/helm/cluster-eks/ci/ci-values.yaml
@@ -10,3 +10,5 @@ connectivity:
           username: giantswarmpull
           password: abcdef
       - endpoint: quay.io
+providerSpecific:
+  awsAccountId: "1234567890"

--- a/helm/cluster-eks/ci/ci-values.yaml
+++ b/helm/cluster-eks/ci/ci-values.yaml
@@ -10,3 +10,5 @@ connectivity:
           username: giantswarmpull
           password: abcdef
       - endpoint: quay.io
+providerSpecific:
+  awsAccountId: "123456789012"

--- a/helm/cluster-eks/ci/ci-values.yaml
+++ b/helm/cluster-eks/ci/ci-values.yaml
@@ -10,5 +10,3 @@ connectivity:
           username: giantswarmpull
           password: abcdef
       - endpoint: quay.io
-providerSpecific:
-  awsAccountId: "123456789012"

--- a/helm/cluster-eks/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-eks/ci/test-wc-minimal-values.yaml
@@ -3,3 +3,5 @@ metadata:
   organization: test
   servicePriority: lowest
 baseDomain: example.com
+providerSpecific:
+  awsAccountId: "123456789012"

--- a/helm/cluster-eks/ci/test-wc-minimal-values.yaml
+++ b/helm/cluster-eks/ci/test-wc-minimal-values.yaml
@@ -4,4 +4,4 @@ metadata:
   servicePriority: lowest
 baseDomain: example.com
 providerSpecific:
-  awsAccountId: "123456789012"
+  awsAccountId: "1234567890"

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -1,6 +1,5 @@
 {{- /*
 Extracts the AWS account ID from an ARN string.
-From our friend ChatGPT
 
 Example usage: {{ include "extractAWSAccountID" "arn:aws:iam::1234567890:role/example-role" }}
 
@@ -8,24 +7,11 @@ Input: An ARN string
 Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
-{{- $colonCount := 0 -}}
-{{- $startIndex := 0 -}}
-{{- $endIndex := 0 -}}
-{{- range $index, $char := . -}}
-  {{- if eq $char ":" -}}
-    {{- if eq $colonCount 4 -}}
-      {{- $endIndex = $index -}}
-      {{- break -}}
-    {{- else -}}
-      {{- $colonCount = add $colonCount 1 -}}
-      {{- $startIndex = add $index 1 -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-{{- substr . $startIndex $endIndex -}}
+{{- $parts := (split ":" . ) -}}
+{{ index $parts 5 }}
 {{- end -}}
 
-{{- define "aws-account" }}
+{{- define "aws-account-id" }}
 {{- $accountID := ""}}
 {{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName }}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) }}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -7,8 +7,7 @@ Input: An ARN string
 Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
-{{- $parts := (split ":" . ) -}}
-{{ index $parts 5 -}}
+{{- (split ":" . )._4 -}}
 {{- end -}}
 
 {{- define "aws-account-id" -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,10 +13,14 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $roleName:= .Values.providerSpecific.awsClusterRoleIdentityName -}}
-{{- $accountID := "*" -}}
+{{- $accountID := "" -}}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" $roleName ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
+{{- if eq $accountID "" -}}
+{{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity $roleName" -}}
+{{- else -}}
 {{- $accountID -}}
+{{- end -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -17,5 +17,5 @@ Output: The AWS account ID
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
-{{- $role -}}
+{{- $accountID -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -12,11 +12,7 @@ Output: The AWS account ID
 {{- end -}}
 
 {{- define "aws-account-id" -}}
-{{- $accountID := "*" -}}
-{{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName -}}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) -}}
-{{- if $role -}}
-{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
-{{- end -}}
-{{ $accountID -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" ".Values.providerSpecific.awsClusterRoleIdentityName" ) -}}
+{{- $accountID := (include "extractAWSAccountID" $role.spec.roleARN) -}}
+{{- if eq $accountID "" -}}*{{- else -}}{{- $accountID -}}{{- end -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -30,7 +30,7 @@ Output: The AWS account ID
 {{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName }}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) }}
 {{- if $role }}
-{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) }
+{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) }}
 {{- end }}
 {{ $accountID }}
 {{- end }}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,7 +13,7 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $roleName:= .Values.providerSpecific.awsClusterRoleIdentityName -}}
-{{- $accountID := $roleName -}}
+{{- $accountID := "*" -}}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" $roleName ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -18,9 +18,5 @@ Output: The AWS account ID
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
-{{- if eq $accountID "" -}}
-{{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity $roleName" -}}
-{{- else -}}
 {{- $accountID -}}
-{{- end -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,8 +13,8 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $roleName:= .Values.providerSpecific.awsClusterRoleIdentityName -}}
-{{- $accountID := "$roleName" -}}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) -}}
+{{- $accountID := $roleName -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" $roleName ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -18,7 +18,7 @@ Output: The AWS account ID
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
-{{- if eq accountID "" -}}
+{{- if eq $accountID "" -}}
 {{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity $roleName" -}}
 {{- else -}}
 {{- $accountID -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -30,7 +30,7 @@ Output: The AWS account ID
 {{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName }}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) }}
 {{- if $role }}
-{{- $accountID := (include "extractAWSAccountID" $role.spec.roleARN) }
+{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) }
 {{- end }}
 {{ $accountID }}
 {{- end }}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -1,0 +1,36 @@
+{{- /*
+Extracts the AWS account ID from an ARN string.
+From our friend ChatGPT
+
+Example usage: {{ include "extractAWSAccountID" "arn:aws:iam::1234567890:role/example-role" }}
+
+Input: An ARN string
+Output: The AWS account ID
+*/ -}}
+{{- define "extractAWSAccountID" -}}
+{{- $colonCount := 0 -}}
+{{- $startIndex := 0 -}}
+{{- $endIndex := 0 -}}
+{{- range $index, $char := . -}}
+  {{- if eq $char ":" -}}
+    {{- if eq $colonCount 4 -}}
+      {{- $endIndex = $index -}}
+      {{- break -}}
+    {{- else -}}
+      {{- $colonCount = add $colonCount 1 -}}
+      {{- $startIndex = add $index 1 -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- substr . $startIndex $endIndex -}}
+{{- end -}}
+
+{{- define "aws-account" }}
+{{- $accountID := ""}}
+{{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName }}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) }}
+{{- if $role }}
+{{- $accountID := (include "extractAWSAccountID" $role.spec.roleARN) }
+{{- end }}
+{{ $accountID }}
+{{- end }}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -7,7 +7,8 @@ Input: An ARN string
 Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
-{{- (split ":" . )._4 -}}
+{{- $parts := (split ":" .)  -}}
+{{- if ge (len parts) "5" -}}{{- $parts._4 -}}{{- end -}}
 {{- end -}}
 
 {{- define "aws-account-id" -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -8,15 +8,15 @@ Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
 {{- $parts := (split ":" . ) -}}
-{{ index $parts 5 }}
+{{ index $parts 5 -}}
 {{- end -}}
 
-{{- define "aws-account-id" }}
-{{- $accountID := ""}}
-{{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName }}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) }}
-{{- if $role }}
-{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) }}
-{{- end }}
-{{ $accountID }}
-{{- end }}
+{{- define "aws-account-id" -}}
+{{- $accountID := "*" -}}
+{{- $roleName := .Values.providerSpecific.awsClusterRoleIdentityName -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) -}}
+{{- if $role -}}
+{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
+{{- end -}}
+{{ $accountID -}}
+{{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,9 +13,9 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $accountID :="*" -}}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" ".Values.providerSpecific.awsClusterRoleIdentityName" ) -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "default2" ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
-{{- $accountID -}}
+{{- $role -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -8,7 +8,7 @@ Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
 {{- $parts := (split ":" .)  -}}
-{{- if ge (len parts) "5" -}}{{- $parts._4 -}}{{- end -}}
+{{- if ge (len $parts) "5" -}}{{- $parts._4 -}}{{- end -}}
 {{- end -}}
 
 {{- define "aws-account-id" -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -12,7 +12,10 @@ Output: The AWS account ID
 {{- end -}}
 
 {{- define "aws-account-id" -}}
+{{- $accountID :="*" -}}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" ".Values.providerSpecific.awsClusterRoleIdentityName" ) -}}
-{{- $accountID := (include "extractAWSAccountID" $role.spec.roleARN) -}}
-{{- if eq $accountID "" -}}*{{- else -}}{{- $accountID -}}{{- end -}}
+{{- if $role -}}
+{{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
+{{- end -}}
+{{- $accountID -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,10 +13,14 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $roleName:= .Values.providerSpecific.awsClusterRoleIdentityName -}}
-{{- $accountID := "" -}}
+{{- $accountID := .Values.providerSpecific.awsAccountId -}}
 {{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" $roleName ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
+{{- if eq accountID "" -}}
+{{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity $roleName" -}}
+{{- else -}}
 {{- $accountID -}}
+{{- end -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -13,7 +13,7 @@ Output: The AWS account ID
 
 {{- define "aws-account-id" -}}
 {{- $accountID :="*" -}}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "default2" ) -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" ".Values.providerSpecific.awsClusterRoleIdentityName" ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -8,7 +8,7 @@ Output: The AWS account ID
 */ -}}
 {{- define "extractAWSAccountID" -}}
 {{- $parts := (split ":" .)  -}}
-{{- if ge (len $parts) "5" -}}{{- $parts._4 -}}{{- end -}}
+{{- if ge (len $parts) 5 -}}{{- $parts._4 -}}{{- end -}}
 {{- end -}}
 
 {{- define "aws-account-id" -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -19,7 +19,7 @@ Output: The AWS account ID
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}
 {{- if eq $accountID "" -}}
-{{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity $roleName" -}}
+{{- fail "failed to extract AWS Account ID from AWSClusterRoleIdentity" -}}
 {{- else -}}
 {{- $accountID -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_awsaccount.tpl
+++ b/helm/cluster-eks/templates/_awsaccount.tpl
@@ -12,8 +12,9 @@ Output: The AWS account ID
 {{- end -}}
 
 {{- define "aws-account-id" -}}
-{{- $accountID :="*" -}}
-{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" ".Values.providerSpecific.awsClusterRoleIdentityName" ) -}}
+{{- $roleName:= .Values.providerSpecific.awsClusterRoleIdentityName -}}
+{{- $accountID := "$roleName" -}}
+{{- $role :=  (lookup "infrastructure.cluster.x-k8s.io/v1beta2" "AWSClusterRoleIdentity" "" "$roleName" ) -}}
 {{- if $role -}}
 {{- $accountID = (include "extractAWSAccountID" $role.spec.roleARN) -}}
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -47,4 +47,10 @@ spec:
     disable: true
   kubeProxy:
     disable: true
+  iamAuthenticatorConfig:
+    mapRoles:
+    - rolearn: arn:aws:iam::{{ include "aws-account" $ }}:role/GiantSwarmAdmin
+      groups: 
+      - system:masters
+      username: cluster-admin
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -49,7 +49,7 @@ spec:
     disable: true
   iamAuthenticatorConfig:
     mapRoles:
-    - rolearn: "arn:aws:iam::{{ include "aws-account-id" $ }}:role/GiantSwarmAdmin"
+    - rolearn: 'arn:aws:iam::{{ include "aws-account-id" $ }}:role/GiantSwarmAdmin'
       groups: 
       - "system:masters"
       username: cluster-admin

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -49,7 +49,7 @@ spec:
     disable: true
   iamAuthenticatorConfig:
     mapRoles:
-    - rolearn: "arn:aws:iam::test:role/GiantSwarmAdmin"
+    - rolearn: "arn:aws:iam::{{ include "aws-account" $ }}:role/GiantSwarmAdmin"
       groups: 
       - "system:masters"
       username: cluster-admin

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -49,7 +49,7 @@ spec:
     disable: true
   iamAuthenticatorConfig:
     mapRoles:
-    - rolearn: arn:aws:iam::{{ include "aws-account" $ }}:role/GiantSwarmAdmin
+    - rolearn: "arn:aws:iam::test:role/GiantSwarmAdmin"
       groups: 
       - "system:masters"
       username: cluster-admin

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -51,6 +51,6 @@ spec:
     mapRoles:
     - rolearn: arn:aws:iam::{{ include "aws-account" $ }}:role/GiantSwarmAdmin
       groups: 
-      - system:masters
+      - "system:masters"
       username: cluster-admin
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -49,7 +49,7 @@ spec:
     disable: true
   iamAuthenticatorConfig:
     mapRoles:
-    - rolearn: "arn:aws:iam::{{ include "aws-account" $ }}:role/GiantSwarmAdmin"
+    - rolearn: "arn:aws:iam::{{ include "aws-account-id" $ }}:role/GiantSwarmAdmin"
       groups: 
       - "system:masters"
       username: cluster-admin

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -507,6 +507,15 @@
                     "title": "Amazon machine image (AMI)",
                     "description": "If specified, this image will be used to provision EC2 instances."
                 },
+                "awsAccountId": {
+                    "type": "string",
+                    "title": "AWS account ID",
+                    "description": "AWS Account ID of the AWSClusterRoleIdentity IAM role, recommendation is to leave this value empty as it will be automatically calculated. This value is needed for tests.",
+                    "default": "",
+                    "maxLength": 12,
+                    "minLength": 0,
+                    "pattern": "^[-0-9]{12}$"
+                },
                 "awsClusterRoleIdentityName": {
                     "type": "string",
                     "title": "Cluster role identity name",

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -514,7 +514,7 @@
                     "default": "",
                     "maxLength": 12,
                     "minLength": 0,
-                    "pattern": "^[-0-9]{12}$"
+                    "pattern": "^[0-9]{0,12}$"
                 },
                 "awsClusterRoleIdentityName": {
                     "type": "string",

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -54,4 +54,5 @@ kubectlImage:
 metadata:
   servicePriority: highest
 providerSpecific:
+  awsAccountId: ""
   awsClusterRoleIdentityName: default


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2609

add aws auth config for the EKS cluster for GiantSwarmAdmin role, its for creating user kubeconfig later

there is a little helm magic that fetches the ARN of the cluster role and parses the aws account ID from it