### PR TITLE
Fill `AWSManagedControlPlane.spec.network.subnets[*].id` field for managed subnets for compatibility with CAPA v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fill `AWSManagedControlPlane.spec.network.subnets[*].id` field for managed subnets for compatibility with CAPA v2.3.0
+
 ## [0.6.2] - 2023-11-08
 
 ### Changed

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -31,19 +31,23 @@ spec:
       cidrBlock: {{ .Values.connectivity.network.vpcCidr }}
     subnets:
     {{- range $j, $subnet := .Values.connectivity.subnets }}
-    {{- range $i, $cidr := $subnet.cidrBlocks }}
-    - cidrBlock: "{{ $cidr.cidr }}"
+    {{- range $i, $cidr := $subnet.cidrBlocks -}}
+    {{/* CAPA v2.3.0 defaults to using the `id` field as subnet name unless it's an unmanaged one (`id` starts with `subnet-`), so use CAPA's previous standard subnet naming scheme */}}
+    - id: "{{ include "resource.default.name" $ }}-subnet-{{ $subnet.isPublic | default false | ternary "public" "private" }}-{{ if eq (len $cidr.availabilityZone) 1 }}{{ include "aws-region" $ }}{{ end }}{{ $cidr.availabilityZone }}"
+      cidrBlock: "{{ $cidr.cidr }}"
       {{- if eq (len $cidr.availabilityZone) 1 }}
       availabilityZone: "{{ include "aws-region" $ }}{{ $cidr.availabilityZone }}"
       {{- else }}
       availabilityZone: "{{ $cidr.availabilityZone }}"
       {{- end }}
       isPublic: {{ $subnet.isPublic | default false }}
+      {{- if or $subnet.tags $cidr.tags }}
       tags:
         {{- toYaml $subnet.tags | nindent 8 }}
         {{- if $cidr.tags }}
         {{- toYaml $cidr.tags | nindent 8 }}
         {{- end }}
+      {{- end }}
     {{- end }}
     {{- end }}
   version: {{ $.Values.internal.kubernetesVersion }}
@@ -59,7 +63,7 @@ spec:
   iamAuthenticatorConfig:
     mapRoles:
     - rolearn: 'arn:aws:iam::{{ include "aws-account-id" $ }}:role/GiantSwarmAdmin'
-      groups: 
+      groups:
       - "system:masters"
       username: cluster-admin
 {{- if $.Values.controlPlane.roleMapping }}

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -272,6 +272,10 @@
                                 "title": "Network",
                                 "items": {
                                     "type": "object",
+                                    "required": [
+                                        "availabilityZone",
+                                        "cidr"
+                                    ],
                                     "properties": {
                                         "availabilityZone": {
                                             "type": "string",


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/2870

Same as https://github.com/giantswarm/cluster-aws/pull/439 does for cluster-aws.

Must be merged _after_ https://github.com/giantswarm/cluster-api-provider-aws-app/pull/192 is deployed.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

Let's trigger these later since this requires newer CAPA version.
