### PR TITLE
Add additionalTags and annotation for cluster-autoscaler in EKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added additionalTags and annotation in managed machine pool template to support cluster-autoscaler in EKS.
+
 ## [0.10.0] - 2023-12-13
 
 ### Changed

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -39,10 +39,8 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   additionalTags:
-    {{- if $.Values.global.providerSpecific.additionalResourceTags -}}{{- toYaml $.Values.global.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
     k8s.io/cluster-autoscaler/enabled: "true"
     k8s.io/cluster-autoscaler/{{ include "resource.default.name" $ }}: "true"
-    giantswarm.io/cluster: {{ include "resource.default.name" $ }}
   availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
   eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
   instanceType:  {{ $value.instanceType }}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -49,7 +49,6 @@ spec:
     k8s.io/cluster-autoscaler/enabled: "true"
     k8s.io/cluster-autoscaler/{{ include "resource.default.name" $ }}: "true"
     giantswarm.io/cluster: {{ include "resource.default.name" $ }}
-    {{- if .Values.global.providerSpecific.additionalResourceTags -}}{{- toYaml .Values.global.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
 ---
 {{ end }}
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -38,17 +38,18 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ $name }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
-  roleName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
-  availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
-  scaling:
-    minSize: {{ $value.minSize | default 1 }}
-    maxSize: {{ $value.maxSize | default 3 }}
-  instanceType:  {{ $value.instanceType }}
-  additionalTags: 
+  additionalTags:
+    {{- if $.Values.global.providerSpecific.additionalResourceTags -}}{{- toYaml $.Values.global.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
     k8s.io/cluster-autoscaler/enabled: "true"
     k8s.io/cluster-autoscaler/{{ include "resource.default.name" $ }}: "true"
     giantswarm.io/cluster: {{ include "resource.default.name" $ }}
+  availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
+  eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
+  instanceType:  {{ $value.instanceType }}
+  roleName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
+  scaling:
+    minSize: {{ $value.minSize | default 1 }}
+    maxSize: {{ $value.maxSize | default 3 }}
 ---
 {{ end }}
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     machine-pool.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ $name }}
+    cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
   labels:
     giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
     {{- include "labels.common" $ | nindent 4 }}
@@ -44,6 +45,11 @@ spec:
     minSize: {{ $value.minSize | default 1 }}
     maxSize: {{ $value.maxSize | default 3 }}
   instanceType:  {{ $value.instanceType }}
+  additionalTags: 
+    k8s.io/cluster-autoscaler/enabled: "true"
+    k8s.io/cluster-autoscaler/{{ include "resource.default.name" $ }}: "true"
+    giantswarm.io/cluster: {{ include "resource.default.name" $ }}
+    {{- if .Values.global.providerSpecific.additionalResourceTags -}}{{- toYaml .Values.global.providerSpecific.additionalResourceTags | nindent 4 }}{{- end}}
 ---
 {{ end }}
 {{- end -}}

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -43,7 +43,6 @@ global:
   providerSpecific:
     awsAccountId: ""
     awsClusterRoleIdentityName: default
-    additionalResourceTags: {}
 internal:
   kubernetesVersion: 1.24.10
   nodePools:

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -43,6 +43,7 @@ global:
   providerSpecific:
     awsAccountId: ""
     awsClusterRoleIdentityName: default
+    additionalResourceTags: {}
 internal:
   kubernetesVersion: 1.24.10
   nodePools:


### PR DESCRIPTION
### What this PR does / why we need it

As part of getting the cluster-autoscaler working in EKS (https://github.com/giantswarm/giantswarm/issues/29315), we need to add the proper tags to the nodepools.
This adds these additionalTags and the annotation for the external autoscaler to the MachinePool resource.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
