### PR TITLE
Use same cluster tag as CAPA

### DIFF
--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -40,7 +40,7 @@ metadata:
 spec:
   additionalTags:
     k8s.io/cluster-autoscaler/enabled: "true"
-    k8s.io/cluster-autoscaler/{{ include "resource.default.name" $ }}: "true"
+    sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}: "owned"
   availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
   eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
   instanceType:  {{ $value.instanceType }}


### PR DESCRIPTION
### What this PR does / why we need it
Fixes the cluster tag to be the same as CAPA, in order to get the autoscaler working.
No changelog update since it's part of the additionalTags still unreleased (not for long hopefully).

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
