### PR TITLE
render-pod-secondary-subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added additionalTags and annotation in managed machine pool template to support cluster-autoscaler in EKS.
+- Render secondary subnets used for pods to the `AWSManagedControlPlane.spec.network.subnets` field.
 
 ## [0.10.0] - 2023-12-13
 

--- a/helm/cluster-eks/README.md
+++ b/helm/cluster-eks/README.md
@@ -39,6 +39,16 @@ Properties within the `.global.connectivity` object
 | `global.connectivity.network.services.cidrBlocks` | **K8s Service subnets**|**Type:** `array`<br/>**Default:** `["172.31.0.0/16"]`|
 | `global.connectivity.network.services.cidrBlocks[*]` | **Service subnet** - IPv4 address range for kubernetes services, in CIDR notation.|**Type:** `string`<br/>**Example:** `"172.31.0.0/16"`<br/>|
 | `global.connectivity.network.vpcCidr` | **VPC subnet** - IPv4 address range to assign to this cluster's VPC, in CIDR notation.|**Type:** `string`<br/>**Default:** `"10.0.0.0/16"`|
+| `global.connectivity.podSubnets` | **Pod Subnets** - Pod Subnets are created and tagged based on this definition.|**Type:** `array`<br/>**Default:** `[{"cidrBlocks":[{"availabilityZone":"a","cidr":"100.64.0.0/18"},{"availabilityZone":"b","cidr":"100.64.64.0/18"},{"availabilityZone":"c","cidr":"100.64.128.0/18"}]}]`|
+| `global.connectivity.podSubnets[*]` | **Subnet**|**Type:** `object`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks` | **Network**|**Type:** `array`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks[*]` |**None**|**Type:** `object`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks[*].availabilityZone` | **Availability zone**|**Type:** `string`<br/>**Example:** `"a"`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks[*].cidr` | **Address range** - IPv4 address range, in CIDR notation.|**Type:** `string`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks[*].tags` | **Tags** - AWS resource tags to assign to this subnet.|**Type:** `object`<br/>|
+| `global.connectivity.podSubnets[*].cidrBlocks[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
+| `global.connectivity.podSubnets[*].tags` | **Tags** - AWS resource tags to assign to this CIDR block.|**Type:** `object`<br/>|
+| `global.connectivity.podSubnets[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
 | `global.connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
 | `global.connectivity.proxy.enabled` | **Enable**|**Type:** `boolean`<br/>|
 | `global.connectivity.proxy.httpProxy` | **HTTP proxy** - To be passed to the HTTP_PROXY environment variable in all hosts.|**Type:** `string`<br/>|

--- a/helm/cluster-eks/README.md
+++ b/helm/cluster-eks/README.md
@@ -39,7 +39,7 @@ Properties within the `.global.connectivity` object
 | `global.connectivity.network.services.cidrBlocks` | **K8s Service subnets**|**Type:** `array`<br/>**Default:** `["172.31.0.0/16"]`|
 | `global.connectivity.network.services.cidrBlocks[*]` | **Service subnet** - IPv4 address range for kubernetes services, in CIDR notation.|**Type:** `string`<br/>**Example:** `"172.31.0.0/16"`<br/>|
 | `global.connectivity.network.vpcCidr` | **VPC subnet** - IPv4 address range to assign to this cluster's VPC, in CIDR notation.|**Type:** `string`<br/>**Default:** `"10.0.0.0/16"`|
-| `global.connectivity.podSubnets` | **Pod Subnets** - Pod Subnets are created and tagged based on this definition.|**Type:** `array`<br/>**Default:** `[{"cidrBlocks":[{"availabilityZone":"a","cidr":"100.64.0.0/18"},{"availabilityZone":"b","cidr":"100.64.64.0/18"},{"availabilityZone":"c","cidr":"100.64.128.0/18"}]}]`|
+| `global.connectivity.podSubnets` | **Pod Subnets** - Pod Subnets are created and tagged based on this definition.|**Type:** `array`<br/>**Default:** `[{"cidrBlocks":[{"availabilityZone":"a","cidr":"100.64.0.0/18","tags":{"sigs.k8s.io/cluster-api-provider-aws/association":"secondary"}},{"availabilityZone":"b","cidr":"100.64.64.0/18","tags":{"sigs.k8s.io/cluster-api-provider-aws/association":"secondary"}},{"availabilityZone":"c","cidr":"100.64.128.0/18","tags":{"sigs.k8s.io/cluster-api-provider-aws/association":"secondary"}}]}]`|
 | `global.connectivity.podSubnets[*]` | **Subnet**|**Type:** `object`<br/>|
 | `global.connectivity.podSubnets[*].cidrBlocks` | **Network**|**Type:** `array`<br/>|
 | `global.connectivity.podSubnets[*].cidrBlocks[*]` |**None**|**Type:** `object`<br/>|

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -50,6 +50,25 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- range $j, $subnet := .Values.global.connectivity.podSubnets }}
+    {{- range $i, $cidr := $subnet.cidrBlocks -}}
+    - id: "{{ include "resource.default.name" $ }}-subnet-secondary-{{ if eq (len $cidr.availabilityZone) 1 }}{{ include "aws-region" $ }}{{ end }}{{ $cidr.availabilityZone }}"
+      cidrBlock: "{{ $cidr.cidr }}"
+      {{- if eq (len $cidr.availabilityZone) 1 }}
+      availabilityZone: "{{ include "aws-region" $ }}{{ $cidr.availabilityZone }}"
+      {{- else }}
+      availabilityZone: "{{ $cidr.availabilityZone }}"
+      {{- end }}
+      isPublic: false
+      {{- if or $subnet.tags $cidr.tags }}
+      tags:
+        {{- toYaml $subnet.tags | nindent 8 }}
+        {{- if $cidr.tags }}
+        {{- toYaml $cidr.tags | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
   version: {{ $.Values.internal.kubernetesVersion }}
   vpcCni:
     disable: true

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -51,7 +51,7 @@ spec:
     {{- end }}
     {{- end }}
     {{- range $j, $subnet := .Values.global.connectivity.podSubnets }}
-    {{- range $i, $cidr := $subnet.cidrBlocks -}}
+    {{- range $i, $cidr := $subnet.cidrBlocks }}
     - id: "{{ include "resource.default.name" $ }}-subnet-secondary-{{ if eq (len $cidr.availabilityZone) 1 }}{{ include "aws-region" $ }}{{ end }}{{ $cidr.availabilityZone }}"
       cidrBlock: "{{ $cidr.cidr }}"
       {{- if eq (len $cidr.availabilityZone) 1 }}

--- a/helm/cluster-eks/templates/_managed_control_plane.tpl
+++ b/helm/cluster-eks/templates/_managed_control_plane.tpl
@@ -62,7 +62,6 @@ spec:
       isPublic: false
       {{- if or $subnet.tags $cidr.tags }}
       tags:
-        {{- toYaml $subnet.tags | nindent 8 }}
         {{- if $cidr.tags }}
         {{- toYaml $cidr.tags | nindent 8 }}
         {{- end }}

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -183,6 +183,76 @@
                                 }
                             }
                         },
+                        "podSubnets": {
+                            "type": "array",
+                            "title": "Pod Subnets",
+                            "description": "Pod Subnets are created and tagged based on this definition.",
+                            "items": {
+                                "type": "object",
+                                "title": "Subnet",
+                                "properties": {
+                                    "cidrBlocks": {
+                                        "type": "array",
+                                        "title": "Network",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "availabilityZone",
+                                                "cidr"
+                                            ],
+                                            "properties": {
+                                                "availabilityZone": {
+                                                    "type": "string",
+                                                    "title": "Availability zone",
+                                                    "examples": [
+                                                        "a"
+                                                    ]
+                                                },
+                                                "cidr": {
+                                                    "type": "string",
+                                                    "title": "Address range",
+                                                    "description": "IPv4 address range, in CIDR notation."
+                                                },
+                                                "tags": {
+                                                    "type": "object",
+                                                    "title": "Tags",
+                                                    "description": "AWS resource tags to assign to this subnet.",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/awsResourceTagValue"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "tags": {
+                                        "type": "object",
+                                        "title": "Tags",
+                                        "description": "AWS resource tags to assign to this CIDR block.",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/awsResourceTagValue"
+                                        }
+                                    }
+                                }
+                            },
+                            "default": [
+                                {
+                                    "cidrBlocks": [
+                                        {
+                                            "availabilityZone": "a",
+                                            "cidr": "100.64.0.0/18"
+                                        },
+                                        {
+                                            "availabilityZone": "b",
+                                            "cidr": "100.64.64.0/18"
+                                        },
+                                        {
+                                            "availabilityZone": "c",
+                                            "cidr": "100.64.128.0/18"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
                         "proxy": {
                             "type": "object",
                             "title": "Proxy",

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -239,15 +239,24 @@
                                     "cidrBlocks": [
                                         {
                                             "availabilityZone": "a",
-                                            "cidr": "100.64.0.0/18"
+                                            "cidr": "100.64.0.0/18",
+                                            "tags": {
+                                                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+                                            }
                                         },
                                         {
                                             "availabilityZone": "b",
-                                            "cidr": "100.64.64.0/18"
+                                            "cidr": "100.64.64.0/18",
+                                            "tags": {
+                                                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+                                            }
                                         },
                                         {
                                             "availabilityZone": "c",
-                                            "cidr": "100.64.128.0/18"
+                                            "cidr": "100.64.128.0/18",
+                                            "tags": {
+                                                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+                                            }
                                         }
                                     ]
                                 }

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -11,6 +11,14 @@ global:
         cidrBlocks:
           - 172.31.0.0/16
       vpcCidr: 10.0.0.0/16
+    podSubnets:
+      - cidrBlocks:
+          - availabilityZone: a
+            cidr: 100.64.0.0/18
+          - availabilityZone: b
+            cidr: 100.64.64.0/18
+          - availabilityZone: c
+            cidr: 100.64.128.0/18
     proxy: {}
     subnets:
       - cidrBlocks:

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -15,10 +15,16 @@ global:
       - cidrBlocks:
           - availabilityZone: a
             cidr: 100.64.0.0/18
+            tags:
+              sigs.k8s.io/cluster-api-provider-aws/association: secondary
           - availabilityZone: b
             cidr: 100.64.64.0/18
+            tags:
+              sigs.k8s.io/cluster-api-provider-aws/association: secondary
           - availabilityZone: c
             cidr: 100.64.128.0/18
+            tags:
+              sigs.k8s.io/cluster-api-provider-aws/association: secondary
     proxy: {}
     subnets:
       - cidrBlocks:


### PR DESCRIPTION
try to fix https://github.com/giantswarm/roadmap/issues/3153 and https://github.com/giantswarm/roadmap/issues/3105

explicitly list secondary subnets in the subnet field in AWSManagedControlPlane CR
