### PR TITLE
remove-helm-keep-on-mp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `"helm.sh/resource-policy": keep` annotation from node pool resources to properly deleted them when it is removed from helm values.
+
 ## [0.12.0] - 2024-01-30
 
 ### Changed

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -4,7 +4,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   annotations:
-    "helm.sh/resource-policy": keep
     machine-pool.giantswarm.io/name: {{ include "resource.default.name" $ }}-{{ $name }}
     cluster.x-k8s.io/replicas-managed-by: "external-autoscaler"
   labels:
@@ -30,8 +29,6 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSManagedMachinePool
 metadata:
-  annotations:
-    "helm.sh/resource-policy": keep
   labels:
     giantswarm.io/machine-pool: {{ include "resource.default.name" $ }}-{{ $name }}
     {{- include "labels.common" $ | nindent 4 }}


### PR DESCRIPTION
### What this PR does / why we need it
- Remove `"helm.sh/resource-policy": keep` annotation from node pool resources to properly delete them when it is removed from helm values.

/run cluster-test-suites
