### PR TITLE
propagate additional tags from cluster-eks to ebs-csi-driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add propagating tags from `cluster-eks` to resources managed my `ebs-csi-driver`.
+
 ## [0.12.0] - 2024-01-30
 
 ### Changed

--- a/helm/cluster-eks/templates/_helpers.tpl
+++ b/helm/cluster-eks/templates/_helpers.tpl
@@ -64,3 +64,10 @@ Where `data` is the data to has on and `global` is the top level scope.
 {{- define "securityContext.runAsGroup" -}}
 1000
 {{- end -}}
+
+{{- define "resource.default.additionalTags" -}}
+{{- if .Values.global.providerSpecific.additionalResourceTags }}
+{{ toYaml .Values.global.providerSpecific.additionalResourceTags }}
+{{- end }}
+giantswarm.io/cluster: {{ include "resource.default.name" $ }}
+{{- end -}}

--- a/helm/cluster-eks/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-eks/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
     remediation:
       retries: 30
   values:
+    extraVolumeTags: {{ include "resource.default.additionalTags" . | nindent 6 }} 
     ciliumNetworkPolicy:
       enabled: true
     controller:


### PR DESCRIPTION
### What this PR does / why we need it

At the moment tagging is not followed for resources created by ebs-csi-driver. This PR add propagation of necessary tags to respective resources.

Towards https://github.com/giantswarm/giantswarm/issues/29583

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
