### PR TITLE
Set machine pool availabilityZoneSubnetType to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- Set `availabilityZoneSubnetType` to `private` for machine pools. This prevents nodes from landing on public subnets. As this is an immutable field, upgrading will cause the existing NodePools will be deleted and replaced with a new one.
+- Set `availabilityZoneSubnetType` to `private` for machine pools. This prevents nodes from landing on public subnets. As this is an immutable field, upgrading will cause the existing machine pool will be deleted and replaced with a new one.
 
 ## [0.14.0] - 2024-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `availabilityZoneSubnetType` to `private` for machine pools. This prevents nodes from landing on public subnets.
+
 ## [0.14.0] - 2024-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Breaking Changes
 
-- Set `availabilityZoneSubnetType` to `private` for machine pools. This prevents nodes from landing on public subnets.
+- Set `availabilityZoneSubnetType` to `private` for machine pools. This prevents nodes from landing on public subnets. As this is an immutable field, upgrading will cause the existing NodePools will be deleted and replaced with a new one.
 
 ## [0.14.0] - 2024-02-13
 

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -2,31 +2,35 @@
 {{ $spec := include "managed-machine-pool-spec" $ }}{{ regexReplaceAll `^\s*#.*$` $spec "" | sha256sum | trunc 5 }}
 {{- end -}}
 {{- define "managed-machine-pool-spec" }}
+{{- $_unused := required "nodePoolName must be set" $.nodePoolName -}}
+{{- $_unused := required "nodePoolObject must be set" $.nodePoolObject -}}
 additionalTags:
   k8s.io/cluster-autoscaler/enabled: "true"
   sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}: "owned"
-availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
+availabilityZones: {{ include "aws-availability-zones" $.nodePoolObject | nindent 2 }}
 availabilityZoneSubnetType: private
-eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
-instanceType:  {{ $value.instanceType }}
-roleName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
+eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $.nodePoolName }}
+instanceType:  {{ $.nodePoolObject.instanceType }}
+roleName: nodes-{{ include "resource.default.name" $ }}-{{ $.nodePoolName }}
 scaling:
-  minSize: {{ $value.minSize | default 1 }}
-  maxSize: {{ $value.maxSize | default 3 }}
-{{- if and $value.subnetIds (gt (len $value.subnetIds) 0) }}
-subnetIDs: {{ $value.subnetIds | toYaml | nindent 2 }}
+  minSize: {{ $.nodePoolObject.minSize | default 1 }}
+  maxSize: {{ $.nodePoolObject.maxSize | default 3 }}
+{{- if and $.nodePoolObject.subnetIds (gt (len $.nodePoolObject.subnetIds) 0) }}
+subnetIDs: {{ $.nodePoolObject.subnetIds | toYaml | nindent 2 }}
 {{- end }}
-{{- if or $value.maxUnavailable $value.maxUnavailablePercentage }}
+{{- if or $.nodePoolObject.maxUnavailable $.nodePoolObject.maxUnavailablePercentage }}
 updateConfig:
-  {{- if $value.maxUnavailable }}
-  maxUnavailable: {{ $value.maxUnavailable }}
-  {{- else if $value.maxUnavailablePercentage }}
-  maxUnavailablePercentage: {{ $value.maxUnavailablePercentage }}
+  {{- if $.nodePoolObject.maxUnavailable }}
+  maxUnavailable: {{ $.nodePoolObject.maxUnavailable }}
+  {{- else if $.nodePoolObject.maxUnavailablePercentage }}
+  maxUnavailablePercentage: {{ $.nodePoolObject.maxUnavailablePercentage }}
   {{- end }}
 {{- end }}
 {{- end }}
 {{- define "machine-pools" }}
 {{- range $name, $value := .Values.global.nodePools | default .Values.internal.nodePools }}
+{{- $ := set $ "nodePoolName" $name }}
+{{- $ := set $ "nodePoolObject" $value }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -39,6 +39,7 @@ spec:
     k8s.io/cluster-autoscaler/enabled: "true"
     sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}: "owned"
   availabilityZones: {{ include "aws-availability-zones" $value | nindent 2 }}
+  availabilityZoneSubnetType: private
   eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}
   instanceType:  {{ $value.instanceType }}
   roleName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -54,7 +54,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSManagedMachinePool
-        name: {{ include "resource.default.name" $ }}-{{ $name }}
+        name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
       version: {{ $.Values.internal.kubernetesVersion }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -65,7 +65,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
   namespace: {{ $.Release.Namespace }}
 spec: {{- include "managed-machine-pool-spec" $ | nindent 2 }}
-    eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
+eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
 ---
 {{ end }}
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -64,9 +64,8 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
   namespace: {{ $.Release.Namespace }}
-spec:
+spec: {{- include "managed-machine-pool-spec" $ | nindent 2 }}
     eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
-    {{- include "managed-machine-pool-spec" $ | nindent 2 }}
 ---
 {{ end }}
 {{- end -}}

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -9,7 +9,6 @@ additionalTags:
   sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}: "owned"
 availabilityZones: {{ include "aws-availability-zones" $.nodePoolObject | nindent 2 }}
 availabilityZoneSubnetType: private
-eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $.nodePoolName }}
 instanceType:  {{ $.nodePoolObject.instanceType }}
 roleName: nodes-{{ include "resource.default.name" $ }}-{{ $.nodePoolName }}
 scaling:
@@ -65,7 +64,9 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
   namespace: {{ $.Release.Namespace }}
-spec: {{- include "managed-machine-pool-spec" $ | nindent 2 }}
+spec:
+    eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
+    {{- include "managed-machine-pool-spec" $ | nindent 2 }}
 ---
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/29585 and also necessary but not enough for https://github.com/giantswarm/giantswarm/issues/28666

This prevents nodes from landing on public subnets, but they can still land on the private subnets intended for the CNI.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
