### PR TITLE
Remove permissive network policies and enable deny by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add network-policies-app with DNS policies enabled. This makes `kube-system` and `giantswarm` namespaces to be `deny` by default.
+- Add `cluster-catalog` and `cluster-test-catalog` HelmRepositories.
+
+### Changed
+
+- Disable and remove permisive policies from cilium-app.
+
 ## [0.16.0] - 2024-03-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Disable and remove permisive policies from cilium-app.
+- Disable and remove permissive policies from cilium-app.
 
 ## [0.16.0] - 2024-03-20
 

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -63,7 +63,8 @@ spec:
       relay:
         enabled: true
     defaultPolicies:
-      enabled: true
+      remove: true
+      enabled: false
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/helm/cluster-eks/templates/cluster-helmrepository.yaml
+++ b/helm/cluster-eks/templates/cluster-helmrepository.yaml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: {{ include "resource.default.name" $ }}-cluster
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  interval: 10m
+  url: https://giantswarm.github.io/cluster-catalog
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: {{ include "resource.default.name" $ }}-cluster-test
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  interval: 10m
+  url: https://giantswarm.github.io/cluster-test-catalog

--- a/helm/cluster-eks/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-eks/templates/netpol-helmrelease.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: {{ include "resource.default.name" $ }}-network-policies
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.global.metadata.description }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  releaseName: network-policies
+  targetNamespace: kube-system
+  storageNamespace: kube-system
+  chart:
+    spec:
+      chart: network-policies
+      # used by renovate
+      # repo: giantswarm/network-policies-app
+      version: 0.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "resource.default.name" $ }}-cluster
+  dependsOn:
+    - name: {{ include "resource.default.name" $ }}-cilium
+      namespace: {{ $.Release.Namespace }}
+  kubeConfig:
+    secretRef:
+      name: {{ include "resource.default.name" $ }}-kubeconfig
+  interval: 10m
+  install:
+    remediation:
+      retries: 30
+  # Default values
+  # https://github.com/giantswarm/network-policies-app/blob/main/helm/network-policies-app/values.yaml
+  values:
+    allowEgressToDNS:
+      enabled: true


### PR DESCRIPTION


### What this PR does / why we need it

- add cluster-catalog and cluster-test-catalog helm repositories
- disable and remove defaultPolicies
- add network-policies-app with DNS policies enabled
- update changelog

Towards https://github.com/giantswarm/roadmap/issues/3261

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
