### PR TITLE
Remove permissive policies removal from cilium-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove permissive policies removal from cilium-app. There shouldn't be any clusters with those policies installed anymore.
+
 ## [0.17.1] - 2024-06-04
 
 ### Changed

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -62,13 +62,3 @@ spec:
     hubble:
       relay:
         enabled: true
-    defaultPolicies:
-      remove: true
-      enabled: false
-      tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists


### PR DESCRIPTION
### What this PR does / why we need it

This is a follow up of https://github.com/giantswarm/cluster-eks/pull/92 cleaning the code after all policies have been removed.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
