### PR TITLE
Set provider specific configuration for cilium CNI ENI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix rendering of control-plane role mapping values.
+- Set `kubeProxyReplacement` to `'true'` instead of deprecated value `strict` in cilium values.
+- Set provider specific configuration for cilium CNI ENI values.
 
 ## [0.17.0] - 2024-06-04
 

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -16,10 +16,10 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.24.0
+      version: 0.27.0-b2e95ed09cba87665cb3a44a588a36dc5a4b6d65
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default
+        name: {{ include "resource.default.name" $ }}-default-test
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -67,7 +67,7 @@ spec:
           "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
           "sigs.k8s.io/cluster-api-provider-aws/role": "private"
     k8sServicePort: '443'
-    kubeProxyReplacement: strict
+    kubeProxyReplacement: 'true'
     hubble:
       relay:
         enabled: true

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
       enabled: true
     ipam:
       mode: eni
+    eksMode: true
     operator:
       extraArgs:
         - "--aws-release-excess-ips=true"

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -45,7 +45,6 @@ spec:
       enabled: true
     ipam:
       mode: eni
-    eksMode: true
     operator:
       extraArgs:
         - "--aws-release-excess-ips=true"
@@ -57,6 +56,16 @@ spec:
       customConf: true
       exclusive: true
       configMap: cilium-cni-configuration
+    cniCustomConf:
+      eni:
+        firstInterfaceIndex: 1
+        securityGroupTags:
+          "kubernetes.io/cluster/{{ include "resource.default.name" $ }}": "owned"
+          "aws:eks:cluster-name": "{{ include "resource.default.name" $ }}"
+        subnetTags:
+          "sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}": "owned"
+          "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+          "sigs.k8s.io/cluster-api-provider-aws/role": "private"
     k8sServicePort: '443'
     kubeProxyReplacement: strict
     hubble:

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -16,10 +16,10 @@ spec:
       chart: cilium
       # used by renovate
       # repo: giantswarm/cilium-app
-      version: 0.27.0-b2e95ed09cba87665cb3a44a588a36dc5a4b6d65
+      version: 0.24.0
       sourceRef:
         kind: HelmRepository
-        name: {{ include "resource.default.name" $ }}-default-test
+        name: {{ include "resource.default.name" $ }}-default
   kubeConfig:
     secretRef:
       name: {{ include "resource.default.name" $ }}-kubeconfig


### PR DESCRIPTION
### What this PR does / why we need it

This PR prepares for an upcoming change in cilium-app which aims to move provider specific configuration to provider charts.

Towards https://github.com/giantswarm/giantswarm/issues/31027


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
