### PR TITLE
Remove eksMode: true from cilium helm values

### DIFF
--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -45,7 +45,6 @@ spec:
       enabled: true
     ipam:
       mode: eni
-    eksMode: true
     operator:
       extraArgs:
         - "--aws-release-excess-ips=true"


### PR DESCRIPTION
### What this PR does / why we need it

This is a follow up to #105 and removes the `eksMode` setting from the cilium-app helm values. No need to explain this in Changelog

/run cluster-test-suites
