### PR TITLE
expose amiType value for managed machine pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose `amiType` for node pools and default to `AL2023_x86_64_STANDARD`.
+
 ## [0.19.0] - 2024-09-19
 
 ### Fixed

--- a/helm/cluster-eks/README.md
+++ b/helm/cluster-eks/README.md
@@ -108,8 +108,9 @@ For Giant Swarm internal use only, not stable, or not supported by UIs.
 | :----------- | :-------------- | :--------------- |
 | `internal.hashSalt` | **Hash salt** - If specified, this token is used as a salt to the hash suffix of some resource names. Can be used to force-recreate some resources.|**Type:** `string`<br/>|
 | `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>**Example:** `"1.25.7"`<br/>**Default:** `"1.25.16"`|
-| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","maxSize":4,"minSize":3}}`|
+| `internal.nodePools` | **Default node pool**|**Type:** `object`<br/>**Default:** `{"def00":{"amiType":"AL2023_x86_64_STANDARD","customNodeLabels":["label=default"],"instanceType":"r6i.xlarge","maxSize":4,"minSize":3}}`|
 | `internal.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `internal.nodePools.PATTERN.amiType` | **AMI type**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `internal.nodePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `internal.nodePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
@@ -163,6 +164,7 @@ Node pools of the cluster. If not specified, this defaults to the value of `inte
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `global.nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
+| `global.nodePools.PATTERN.amiType` | **AMI type**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|
 | `global.nodePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9][-a-z0-9]{3,18}[a-z0-9]$`<br/>|

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -7,6 +7,7 @@
 additionalTags:
   k8s.io/cluster-autoscaler/enabled: "true"
   sigs.k8s.io/cluster-api-provider-aws/cluster/{{ include "resource.default.name" $ }}: "owned"
+amiType: {{ $.nodePoolObject.amiType }}
 availabilityZones: {{ include "aws-availability-zones" $.nodePoolObject | nindent 2 }}
 availabilityZoneSubnetType: private
 instanceType:  {{ $.nodePoolObject.instanceType }}

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -15,7 +15,12 @@
             "properties": {
                 "amiType": {
                     "type": "string",
-                    "title": "AMI type"
+                    "title": "AMI type",
+                    "enum": [
+                        "AL2023_x86_64_STANDARD",
+                        "AL2023_ARM_64_STANDARD",
+                        "CUSTOM"
+                    ]
                 },
                 "availabilityZones": {
                     "type": "array",

--- a/helm/cluster-eks/values.schema.json
+++ b/helm/cluster-eks/values.schema.json
@@ -13,6 +13,10 @@
             "type": "object",
             "title": "Node pool",
             "properties": {
+                "amiType": {
+                    "type": "string",
+                    "title": "AMI type"
+                },
                 "availabilityZones": {
                     "type": "array",
                     "title": "Availability zones",
@@ -710,6 +714,7 @@
                     },
                     "default": {
                         "def00": {
+                            "amiType": "AL2023_x86_64_STANDARD",
                             "customNodeLabels": [
                                 "label=default"
                             ],

--- a/helm/cluster-eks/values.yaml
+++ b/helm/cluster-eks/values.yaml
@@ -64,6 +64,7 @@ internal:
   kubernetesVersion: 1.25.16
   nodePools:
     def00:
+      amiType: AL2023_x86_64_STANDARD
       customNodeLabels:
         - label=default
       instanceType: r6i.xlarge


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/33814

AL2 is deprecated and no longer available for clusters created with kubernetes 1.33 and later.

### Checklist

- [x] Update changelog in CHANGELOG.md.
