### PR TITLE
Update API version for HelmReleases to helm.toolkit.fluxcd.io/v2beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expose `amiType` for node pools and default to `AL2023_x86_64_STANDARD`.
 
+### Changed
+
+- Update API version for HelmReleases to `helm.toolkit.fluxcd.io/v2beta2`.
+
 ## [0.19.0] - 2024-09-19
 
 ### Fixed

--- a/helm/cluster-eks/templates/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-eks/templates/aws-ebs-csi-driver-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-aws-ebs-csi-driver

--- a/helm/cluster-eks/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-eks/templates/cilium-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-cilium

--- a/helm/cluster-eks/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-eks/templates/coredns-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-coredns

--- a/helm/cluster-eks/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-eks/templates/netpol-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-network-policies

--- a/helm/cluster-eks/templates/vpa-crd-helmrelease.yaml
+++ b/helm/cluster-eks/templates/vpa-crd-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-vertical-pod-autoscaler-crd


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/33814

### What this PR does / why we need it

Bumps the helmrelease API version to the latest supported.

### Checklist

- [x] Update changelog in CHANGELOG.md.
