### PR TITLE
Fix ManagedMachinePool spec indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update API version for HelmReleases to `helm.toolkit.fluxcd.io/v2beta2`.
 - Disable privilege escalation for helmrelease cleanup job.
 - Use `giantswarm/cluster` to render the `Cluster` object.
+- Fix ManagedMachinePool spec.
 
 ## [0.19.0] - 2024-09-19
 

--- a/helm/cluster-eks/templates/_managed_machine_pools.tpl
+++ b/helm/cluster-eks/templates/_managed_machine_pools.tpl
@@ -66,7 +66,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
   namespace: {{ $.Release.Namespace }}
 spec: {{- include "managed-machine-pool-spec" $ | nindent 2 }}
-eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
+  eksNodegroupName: nodes-{{ include "resource.default.name" $ }}-{{ $name }}-{{ include "managed-machine-pool-spec-hash" $ }}
 ---
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
minor fix to indentation in the machine pool spec. the eks node pool name value should come under `.spec`, otherwise this happens:

```
I0729 13:53:01.587781  461386 warnings.go:110] "Warning: unknown field \"eksNodegroupName\""
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
