### PR TITLE
Only use `ServiceMonitor` and `VerticalPodAutoscaler` in aws-ebs-csi-driver if needed dependencies are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `coreDnsExtensions` config template from `EKSCorednsHelmValues` to `EKSCoreDNSExtensionsHelmValues` to avoid confusion with the `coreDns` template name.
 - Move `coreDns` Helm values config from `apps/` to the helmrelease config file, since coreDns is deployed as a HelmRelease.
 - Use `cluster.providerIntegration.workers.defaultNodePools` of parent chart and define a working default for `replicas` (must be between `minSize` and `maxSize`).
+- Only use `ServiceMonitor` and `VerticalPodAutoscaler` in aws-ebs-csi-driver if needed dependencies are enabled
 
 ## [1.3.0] - 2026-02-27
 

--- a/helm/cluster-eks/templates/helmreleases/aws-ebs-csi-driver-helmrelease.yaml
+++ b/helm/cluster-eks/templates/helmreleases/aws-ebs-csi-driver-helmrelease.yaml
@@ -3,7 +3,7 @@
 {{- define "defaultAwsEbsCsiDriverHelmValues" }}
 clusterID: {{ include "resource.default.name" $ }}
 clusterName: {{ include "resource.default.name" $ }}
-extraVolumeTags: {{ include "resource.default.additionalTags" . | nindent 2 }} 
+extraVolumeTags: {{ include "resource.default.additionalTags" . | nindent 2 }}
 {{- if (.Values.global.connectivity.proxy).enabled }}
 proxy:
   noProxy: "{{ include "cluster.connectivity.proxy.noProxy" (dict "global" $.Values.global "providerIntegration" $.Values.cluster.providerIntegration) }}"
@@ -14,7 +14,19 @@ global:
   image:
     registry: {{ include "awsContainerImageRegistry" $ }}
   podSecurityStandards:
-    enforced: {{ .Values.global.podSecurityStandards.enforced }}
+    {{/* PolicyException CRD only available with security-bundle installed */}}
+    enforced: {{ and .Values.global.podSecurityStandards.enforced $.Values.cluster.providerIntegration.apps.securityBundle.enable }}
+{{- if not $.Values.cluster.providerIntegration.apps.verticalPodAutoscalerCrd.enable }}
+verticalPodAutoscaler:
+  enabled: false
+{{- end }}
+{{- if not $.Values.cluster.providerIntegration.apps.observabilityBundle.enable }}
+upstream:
+  controller:
+    enableMetrics: false
+    serviceMonitor:
+      forceEnable: false
+{{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/36119

This avoids `HelmRelease` installation errors.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
If you want to skip the E2E tests, remove the following line and add the `skip/ci` label to skip the check.

Note: Tests are not automatically executed when creating a draft PR. If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites
