### PR TITLE
feat: Run the full E2E suite set automatically on release PRs

### DIFF
--- a/.github/release-pr-body.md
+++ b/.github/release-pr-body.md
@@ -1,0 +1,14 @@
+<!--
+Used verbatim as the body of release PRs created by giantswarm/github-workflows
+(see .github/workflows/zz_generated.create_release_pr.yaml).
+
+The `/run` line makes Tekton start the E2E tests as soon as the release PR is
+opened. cluster-test-suites expands to every suite for this provider when it
+detects a release PR, so the full set runs before the release is tagged.
+
+See https://github.com/giantswarm/roadmap/issues/4334
+-->
+
+The full set of E2E test suites for this provider runs automatically on this release PR.
+
+/run cluster-test-suites

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI: Run the full set of E2E test suites automatically on release PRs, via `.github/release-pr-body.md`. Towards https://github.com/giantswarm/roadmap/issues/4334
+
 ## [3.0.0] - 2026-08-05
 
 ### Changed


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

Release PRs are created with an empty body, so Tekton — which starts the tests from a `/run` line in the PR body — never ran anything on them. Running the E2E tests depended on someone remembering to comment, and release PRs were merged with no run at all (cluster-aws#2036, cluster-cloud-director#573, cluster-vsphere#527).

Adds `.github/release-pr-body.md`, which giantswarm/github-workflows#266 uses as the release PR body. `cluster-test-suites` already expands to **every** suite for this provider once it detects a release PR, so no suite parameters are needed here.

Has no effect until giantswarm/github-workflows#266 merges; until then the file is simply unused.